### PR TITLE
Fix publishing date on the “Feature Switches, Inheritance and Agile” article

### DIFF
--- a/1609/feature-switches-agile-scala-jmx/index.html
+++ b/1609/feature-switches-agile-scala-jmx/index.html
@@ -119,7 +119,7 @@ figure {
   <article class="h-entry">
     <header>
       <h1>Feature Switches, Inheritance and Agile with Scala &amp; JMX on the JVM</h1>
-      <h2>By <a href="/" class="p-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2016-09-20 12:00:00">Sep 30, 2016</time></h2>
+      <h2>By <a href="/" class="p-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2016-09-30T12:38:59.026Z">Sep 30, 2016</time></h2>
       This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/1609/feature-switches-agile-scala-jmx/index.html">edited on GitHub</a>.
     </header>
 


### PR DESCRIPTION
The Feature Switches, Inheritance and Agile article was set to the wrong day (the 20th) and used a completely artificial time. This update fixes the day and adds the time from the original Hacker Noon posting.