### PR TITLE
Migrate: Unit testing is simple, May 2017

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,7 +72,7 @@ cp 1705/greenfield-technical-debt/index.html out/1705/greenfield-technical-debt/
 cp 1705/greenfield-technical-debt/dont-be-like-this.jpeg out/1705/greenfield-technical-debt/
 
 mkdir -p out/unit-testing-is-simple
-cp unit-testing-is-simple/index.html out/unit-testing-is-simple/
+php embed-code.php unit-testing-is-simple/index.html > out/unit-testing-is-simple/index.html
 
 function do_1612() {
 mkdir -p out/1612/essential-scala-tutorial/

--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,9 @@ mkdir -p out/1705/greenfield-technical-debt
 cp 1705/greenfield-technical-debt/index.html out/1705/greenfield-technical-debt/
 cp 1705/greenfield-technical-debt/dont-be-like-this.jpeg out/1705/greenfield-technical-debt/
 
+mkdir -p out/unit-testing-is-simple
+cp unit-testing-is-simple/index.html out/unit-testing-is-simple/
+
 function do_1612() {
 mkdir -p out/1612/essential-scala-tutorial/
 mkdir -p out/1611/firebase-static-site-deploy/

--- a/embed-code.php
+++ b/embed-code.php
@@ -1,0 +1,57 @@
+<?php
+
+function process_file($filename) {
+    libxml_use_internal_errors(true);
+    $dom = new \DOMDocument();
+    $dom->loadHTMLFile($filename);
+    $xpath = new \DOMXpath($dom);
+    $elements = $xpath->query('//pre[@data-code-include]');
+    foreach ($elements as $element) {
+        $codefile = pathinfo($filename, PATHINFO_DIRNAME)
+            . DIRECTORY_SEPARATOR
+            . $element->getAttribute('data-code-include');
+        $language = '';
+        if ($element->hasAttribute('data-code-language')) {
+            $language = $element->getAttribute('data-code-language');
+        } elseif ($element->hasAttribute('class')) {
+            $classes = explode(' ', $element->getAttribute('class'));
+            foreach ($classes as $class) {
+                if (strpos($class, 'language-') === 0) {
+                    $language = substr($class, 9);
+                    break;
+                }
+            }
+        }
+        if ($language === '') {
+            $extension = pathinfo($codefile, PATHINFO_EXTENSION);
+            $extensionsMap = [
+                'py' => 'python',
+                'sh' => 'bash',
+                'js' => 'javascript',
+            ];
+            if (array_key_exists($extension, $extensionsMap)) {
+                $language = $extensionsMap[$extension];
+            } else {
+                $language = $extension;
+            }
+        }
+        $code = $dom->createElement('code');
+        $code->setAttribute('class', 'language-' . $language);
+        $code->appendChild($dom->createTextNode(rtrim(file_get_contents($codefile),"\n\r")));
+        $element->appendChild($code);
+    }
+    echo $dom->saveHTML();
+}
+
+$failed = false;
+foreach(array_slice($argv, 1) as $filename) {
+    if (pathinfo($filename, PATHINFO_EXTENSION) === 'html') {
+        process_file($filename);
+    } else {
+        $failed = true;
+        error_log("Cannot process file $filename because no .html extension.");
+    }
+}
+if ( $failed ) {
+    exit(1);
+}

--- a/index.php
+++ b/index.php
@@ -49,7 +49,7 @@ require(dirname(__FILE__).DIRECTORY_SEPARATOR."shared".DIRECTORY_SEPARATOR."rend
             <p>Also on <a href="https://plus.google.com/collection/oFuHlB" target="_blank">Google+</a>.</p>
             <ul>
                 <li class="h-entry">
-                    <a class="p-name" href="https://dev.to/scalawilliam/unit-testing-is-simple">Unit testing is simple</a>,
+                    <a class="p-name" href="/unit-testing-is-simple/">Unit testing is simple</a>,
                     <time class="dt-published" datetime="2017-05-04">May 2017</time>
                 </li>
                 <li class="h-entry">

--- a/unit-testing-is-simple/bash-out-1.txt
+++ b/unit-testing-is-simple/bash-out-1.txt
@@ -1,0 +1,8 @@
+seq 1 5 | bash inc.sh
+2
+3
+4
+5
+6
+echo $?
+0

--- a/unit-testing-is-simple/bash-out-2.txt
+++ b/unit-testing-is-simple/bash-out-2.txt
@@ -1,0 +1,3 @@
+seq 1 5 | bash inc.sh
+echo $?
+1

--- a/unit-testing-is-simple/inc.js
+++ b/unit-testing-is-simple/inc.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+
+function increment(n) {
+  return n + 2;
+}
+
+assert.equal(2, increment(1));

--- a/unit-testing-is-simple/inc.py
+++ b/unit-testing-is-simple/inc.py
@@ -1,0 +1,4 @@
+def increment(n):
+  return n + 2
+
+assert increment(2) == 3

--- a/unit-testing-is-simple/inc.scala
+++ b/unit-testing-is-simple/inc.scala
@@ -1,0 +1,2 @@
+def inc(n: Int) = n + 2
+assert(inc(1) == 2)

--- a/unit-testing-is-simple/inc.sh
+++ b/unit-testing-is-simple/inc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+increment() {
+    echo $(("$1"+1))
+}
+
+# If this assertion fails, the whole thing quits 
+[ 3 -eq $(increment 2) ] || exit 1
+
+# Increment a stream of numbers
+while read n; do
+    increment $n;
+done

--- a/unit-testing-is-simple/index.html
+++ b/unit-testing-is-simple/index.html
@@ -92,6 +92,31 @@ figure {
   padding: 0.5em;
 }
 .clear { clear:both; }
+
+        /* Styles for the comment section. */
+        #comments {
+            margin-top: 3em;
+        }
+        #comments header {
+            border: 1px solid #AAA;
+            border-radius: 5px 5px 0 0;
+            padding: .5em 1em;
+            margin: 0 2em;
+        }
+        #comments main {
+            border: 1px solid #AAA;
+            border-top: 0px;
+            border-radius: 0 0 5px 5px;
+            padding: 0 1em;
+            margin: 0 2em;
+            overflow: auto;
+        }
+        #comments article {
+            margin-bottom: 2em;
+        }
+        #comments article article {
+            margin: 2em 0 0 2em;
+        }
     </style>
 
 
@@ -120,10 +145,10 @@ figure {
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@ScalaWilliam">
 </head>
-<body>
-  <article class="h-entry">
+<body class="h-entry">
+  <article>
     <header>
-      <h1>Unit testing is simple</h1>
+      <h1 class="p-name">Unit testing is simple</h1>
       <h2>By <a href="/" class="u-author h-card">William Narmontas</a>, <a class="u-url" href="/unit-testing-is-simple"><time class="dt-published" datetime="2017-05-04">May 4, 2017</time></a></h2>
       <p>This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/unit-testing-is-simple/index.html">edited on GitHub</a>.</p>
       <p>Original article at <a href="https://dev.to/scalawilliam/unit-testing-is-simple" class="u-syndication">The Practical Dev</a>.</p>
@@ -229,5 +254,234 @@ echo $?
         <p>Now you have no excuse for not writing at least a few tests in your code.</p>
     </section>
 </article>
+<section id="comments">
+    <h1>Comments</h1>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/lennartb" target="_blank">Lennart</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/a8j" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>Sadly, most posts/introductions about unit tests are usually way too simple with easy pure functions that just calculate some number. You don't have this kind of logic in real-world applications.</p>
+            <p>I have to deal with way more complicated scenarios daily involving object graphs that require initialization, external dependencies, drag and drop, framework objects that you can't mock and so on. I've yet to read a tutorial (or even book) that covers these cases.</p>
+            <p>How do I deal with legacy code that is not necessarily bad, but doesn't use DI and is not as easily testable as it ideally should be? How do I test public methods that don't return a value, but change something deeper down the call stack (internally)? I'd really like to read an article about how to tackle these problems!</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/a96" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>Great questions! I actually have a whole lot to say on this but that'd have to be a whole new article.</p>
+                    <p>For greenfield, functional programming is the answer. You don't need to test "changes deeper down the call stack" because there's no such thing as a change. Pass a value, get a value back.</p>
+                    <p>We've written large complex applications with two flavours of code:</p>
+                    <ul>
+                        <li>unit-tested functional code.</li>
+                        <li>functional/acceptance-tested mutable/side-effecting code, which wires up the functional code.</li>
+                    </ul>
+                    <p>Both flavours test-driven, not test-after.</p>
+                    <hr>
+                    <p>You say that this legacy code is not necessarily bad but missing testability. Assuming this, I say the following:</p>
+                    <ul>
+                        <li>Approach it by repeatedly extracting as much purity from mutable parts as you can. You'll find there's a lot of code that does not actually need to be mutable.</li>
+                        <li>Turn the left-over mutable parts into immutable parts.</li>
+                        <li>Only do this incrementally and not in a single step. Small commits, small pull requests.</li>
+                    </ul>
+                    <p>The cost of fixing is still less than rewriting from scratch. See Joel Spolsky's article about "Things you should never do".</p>
+                </main>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/fortegabbm" target="_blank">ferOrtega</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6jc" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>Not only simple but with functionality like Live Unit Testing (Visual Studio 2017) is also awesome.</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6jo" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>This makes me think that I should list a few unit testing frameworks, to make the article more complete.</p>
+                </main>
+                <section>
+                    <article class="u-comment h-cite">
+                        <header>
+                            <a class="p-author h-card" href="https://dev.to/jevenson" target="_blank">Josh Evenson</a>
+                            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6kn" target="_blank">commented</a>:
+                        </header>
+                        <main class="e-content p-name">
+                            <p>XUnit! Moq! TestDouble! Karma! Jasmine!</p>
+                        </main>
+                    </article>
+                    <article class="u-comment h-cite">
+                        <header>
+                            <a class="p-author h-card" href="https://dev.to/fortegabbm" target="_blank">ferOrtega</a>
+                            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6k0" target="_blank">commented</a>:
+                        </header>
+                        <main class="e-content p-name">
+                            <p>Don't worry. The article is complete enough. ;)</p>
+                        </main>
+                    </article>
+                </section>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/alancampora" target="_blank">Alan Campora</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/71a" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>This is a good starting point! I'm not an expert on this topic, but unit testing seems easy when you test "pure" functions. What happens when you have different results for the same input? Or functions that just call functions and you have to start using spies? Would be great if you go deeper in those topics!</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/71f" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>Great question!</p>
+                    <p>Exactly! If you want to make your life as easy as possible, you'll have as high a percentage of pure functions as possible. This requires explicit effort.</p>
+                    <p>While you can achieve purity in any language, functional programming languages let you achieve it far more easily.</p>
+                    <p>Personally most side-effecting code I write is also externally facing code, which makes them Integration Tests rather than Unit tests.</p>
+                    <p>I very rarely use spies/mocks and the like. Brittle.</p>
+                </main>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/kylessg" target="_blank">Kyle Johnson</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6km" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>I have a feeling you've got quite a lot more to say about this area than you let on in this post. It'd be quite hard for anyone to gain anything this post , on the one hand they'd have to understand how assertions fit into the bigger picture of unit testing in medium to large scale apps whilst on the other hand they don't have anything but a few simple assertion statements to work with - which they probably already knew in their day to day language</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6l5" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>Good comment, your assessment is accurate! I'm however not sure how to express it better though.</p>
+                    <p>I have another article coming on Medium related to building things incrementally though, should be out today or tomorrow.</p>
+                </main>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/steinbjo" target="_blank">Stein B. Johansen</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/a8f" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>For function, I agree, but is this unit-test or integration testing?</p>
+            <p>If you run up your application, and test how the functionality works from an external application, I would not call it "Unit-test" (or as it should have been called: Class test).</p>
+            <p>You can debate that your function/microservice is a "unit", but I do disagree, especially if it comes with a web-server which most microservices do.</p>
+        </main>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/daveoncode" target="_blank">Davide Zanotti</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6ji" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>unit testing is far more complex than writing an assertion statement... this post is pointless :/</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6jm" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>What do you have in mind? I'd like to know to improve the post :)</p>
+                    <p>I do use test frameworks extensively and find people have severe resistance to testing because of the learning curve. So this is a simple alternative for the newbie.</p>
+                </main>
+                <section>
+                    <article class="u-comment h-cite">
+                        <header>
+                            <a class="p-author h-card" href="https://dev.to/daveoncode" target="_blank">Davide Zanotti</a>
+                            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6k3" target="_blank">commented</a>:
+                        </header>
+                        <main class="e-content p-name">
+                            <p>What you define as "unit test" in your post are actually mere assertions. They are helpful to ensure the sound state of your internal code but not for documenting and ensuring that your code behaves correctly as expected (as in a unit test). So, I'm not saying that assertions in code are useless, I'm saying that it's not unit testing! moreover an unit test has usually multiple assertions because the goal is to thest a method (the unit) under different scenarios!</p>
+                        </main>
+                    </article>
+                </section>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/theednaffattack" target="_blank">Eddie Naff</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6je" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>hunh. To me this is by far the hardest part of development. I'm not a specialist though. Different strokes for different folks I guess</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6jn" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>Why is that the case for you? I'd like to find out so I can solve your problem and make testing better.</p>
+                    <p>I rarely ever have to debug or println any more - just use a test.</p>
+                </main>
+                <section>
+                    <article class="u-comment h-cite">
+                        <header>
+                            <a class="p-author h-card" href="https://dev.to/theednaffattack" target="_blank">Eddie Naff</a>
+                            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6k2" target="_blank">commented</a>:
+                        </header>
+                        <main class="e-content p-name">
+                            <p>Well, for me it's the tooling. Getting everything to work together. The point of your article seems to be not using things like Mocha or what-have-you but I personally would be afraid to test without it. Or rather, I have no idea how I would use your method day-to-day.</p>
+                        </main>
+                    </article>
+                </section>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/mortoray" target="_blank">edA-qa mort-ora-y</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6k1" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>This post is a good reminder that you can start off simple and grow into a framework as you need it. Unit testing is ultimately about the tests themselves, and this gives you the straightest path to writing them.</p>
+        </main>
+        <section>
+            <article class="u-comment h-cite">
+                <header>
+                    <a class="p-author h-card" href="/">William Narmontas</a>
+                    <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6l0" target="_blank">commented</a>:
+                </header>
+                <main class="e-content p-name">
+                    <p>That is exactly my intention. Thanks! :)</p>
+                </main>
+            </article>
+        </section>
+    </article>
+    <article class="u-comment h-cite">
+        <header>
+            <a class="p-author h-card" href="https://dev.to/rpalo" target="_blank">Ryan Palo</a>
+            <a class="u-url" href="https://dev.to/scalawilliam/unit-testing-is-simple/comments/6jj" target="_blank">commented</a>:
+        </header>
+        <main class="e-content p-name">
+            <p>That's so awesome! I didn't know about the Bash or Node ones. I've wanted to have some kind of testing for some of my Bash scripts. Thanks for sharing!</p>
+        </main>
+    </article>
+</section>
 </body>
 </html>

--- a/unit-testing-is-simple/index.html
+++ b/unit-testing-is-simple/index.html
@@ -14,6 +14,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-bash.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-python.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-javascript.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-java.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-scala.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/command-line/prism-command-line.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/command-line/prism-command-line.min.css">

--- a/unit-testing-is-simple/index.html
+++ b/unit-testing-is-simple/index.html
@@ -172,74 +172,25 @@ figure {
         <p>These examples are for a very basic piece of code and are intentionally minimalistic, to demonstrate that you needn't use a test framework to get started with - though one will be very necessary when you scale your application.</p>
         <h3>Bash</h3>
         <p>Here's a bash script <code>inc.sh</code> with a basic assertion and some main code:</p>
-        <pre><code class="language-bash">#!/bin/bash
-
-increment() {
-    echo $(("$1"+1))
-}
-
-# If this assertion fails, the whole thing quits 
-[ 3 -eq $(increment 2) ] || exit 1
-
-# Increment a stream of numbers
-while read n; do
-    increment $n;
-done</code></pre>
+        <pre data-code-include="inc.sh"></pre>
         <p>If we run:</p>
-        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-6, 8"><code class="language-bash">seq 1 5 | bash inc.sh
-2
-3
-4
-5
-6
-echo $?
-0</code></pre>
+        <pre data-code-include="bash-out-1.txt" class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-6, 8"><code class="language-bash"></pre>
         <p>Exit code is 0. But if we broke the function, and put 2 instead of 1, we get:</p>
-        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="3"><code class="language-bash">seq 1 5 | bash inc.sh
-echo $?
-1</code></pre>
+        <pre data-code-include="bash-out-2.txt" class="command-line language-bash" data-user="william" data-host="localhost" data-output="3"></pre>
         <h3>Python</h3>
         <p>This is easy to achieve in any language really. <a href="https://docs.python.org/2/reference/simple_stmts.html#the-assert-statement" target="_blank">Python assertions</a>:</p>
         <p>Broken test in file <code>inc.py</code>:</p>
-        <pre><code class="language-python">def increment(n):
-  return n + 2
-
-assert increment(2) == 3</code></pre>
-        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-5,7"><code class="language-bash">python inc.py
-Traceback (most recent call last):
-  File "inc.py", line 4, in <module>
-    assert increment(2) == 3
-AssertionError
-echo $?
-1</code></pre>
+        <pre data-code-include="inc.py"></pre>
+        <pre data-code-include="python-out.txt" class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-5,7"></pre>
         <h3>Node.js</h3>
         <p>Comes with <a href="https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message" target="_blank">assertions built in</a>.</p>
         <p>Broken test in file <code>inc.js</code>:</p>
-        <pre><code class="language-javascript">const assert = require('assert');
-
-function increment(n) {
-  return n + 2;
-}
-
-assert.equal(2, increment(1));</code></pre>
-        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-8,10"><code class="language-bash">node inc.js
-
-assert.js:81
-  throw new assert.AssertionError({
-  ^
-AssertionError: 2 == 3
-
-...
-echo $?
-1</code></pre>
+        <pre data-code-include="inc.js"></pre>
+        <pre data-code-include="node-out.txt" class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-8,10"></pre>
         <h3><a href="http://scala-lang.org/" target="_blank">Scala</a></h3>
         <p>Comes with assert.</p>
-        <pre><code class="language-scala">def inc(n: Int) = n + 2
-assert(inc(1) == 2)</code></pre>
-        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2,4"><code class="language-bash">scala inc.scala
-java.lang.AssertionError: assertion failed
-echo $?
-1</code></pre>
+        <pre data-code-include="inc.scala"></pre>
+        <pre data-code-include="scala-out.txt" class="command-line language-bash" data-user="william" data-host="localhost" data-output="2,4"></pre>
         <h3>Why is this important?</h3>
         <p>You can get started light with several assertions and work your way up to proper test suites.</p>
         <h3>So what are test frameworks for?</h3>

--- a/unit-testing-is-simple/index.html
+++ b/unit-testing-is-simple/index.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,700,900%7CRoboto+Mono" rel="stylesheet">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.13/clipboard.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/toolbar/prism-toolbar.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/toolbar/prism-toolbar.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-bash.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-python.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-javascript.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/components/prism-scala.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/command-line/prism-command-line.min.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/command-line/prism-command-line.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism-okaidia.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js"></script>
+    <style type="text/css">
+    body {
+        font-family: 'Roboto', sans-serif;
+        line-height:1.6;
+        color:rgb(5,5,5);
+        background:rgb(255,255,255);
+        max-width:60em;
+    }
+        code {
+            font-family: 'Roboto Mono', monospace;
+        }
+        header {
+            padding-bottom: 1em;
+        }
+        header pre {
+            border:2px solid;
+            border-color: firebrick;
+            text-align: center;
+            padding:0.6em;
+            overflow-x:scroll;
+        }
+        header code {
+            font-size:1.6em;
+            font-weight:bold;
+        }
+        ul {
+            list-style-type: square;
+        }
+                a {
+            color:darkslategrey;
+        }
+        a:hover {
+            color:darkslateblue;
+        }
+
+        .token.operator {
+        background:none;
+        }
+
+
+             nav button {
+                box-shadow: 0 0 0 1px rgba(0,0,0,.15) inset,0 0 6px rgba(0,0,0,.2) inset;
+    font-family: inherit;
+    font-size: 100%;
+    padding: .5em 1em;
+    color: #444;
+    border: 1px solid #999;
+    border: 0 rgba(0,0,0,0);
+    background-color: #E6E6E6;
+    text-decoration: none;
+    border-radius: 2px;
+        }
+        nav.hide ul {
+            display:none;
+        }
+nav ul {
+            list-style-type: none;
+        }
+nav li:before {
+            content: "- ";
+        }
+figure {
+    display:inline-block;
+  text-align: center;
+  font-style: italic;
+  font-size: smaller;
+  text-indent: 0;
+  border: thin silver solid;
+    box-shadow: 1px 1px 3px black;
+  margin: 0.5em;
+  padding: 0.5em;
+}
+.clear { clear:both; }
+    </style>
+
+
+    <title>Unit testing is simple</title>
+
+<meta name="twitter:title" content="Unit testing is simple">
+<meta property="og:title" content="Unit testing is simple">
+<meta itemprop="name" content="Unit testing is simple">
+<meta property="og:url" content="/unit-testing-is-simple">
+<link rel="canonical" href="/unit-testing-is-simple">
+<!-- http://ogp.me/ -->
+<meta property="og:type" content="article">
+<meta property="article:published_time" content="2017-05-04">
+<meta property="article:modified_time" content="2017-05-04">
+<meta property="og:description" content="William Narmontas shows how simple unit testing is.">
+<meta itemprop="description" content="William Narmontas shows how simple unit testing is.">
+<meta name="description" content="William Narmontas shows how simple unit testing is.">
+<meta name="twitter:description" content="William Narmontas shows how simple unit testing is.">
+<meta property="og:site_name" content="Scala William">
+<link rel="author" href="https://plus.google.com/u/0/103489630517643950426/">
+<link rel="publisher" href="https://plus.google.com/u/0/103489630517643950426/">
+<meta property="og:image" content="https://avatars2.githubusercontent.com/u/2464813">
+<meta itemprop="image" content="https://avatars2.githubusercontent.com/u/2464813">
+<meta name="twitter:image" content="https://avatars2.githubusercontent.com/u/2464813">
+<meta name="author" content="William Narmontas">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@ScalaWilliam">
+</head>
+<body>
+  <article class="h-entry">
+    <header>
+      <h1>Unit testing is simple</h1>
+      <h2>By <a href="/" class="u-author h-card">William Narmontas</a>, <a class="u-url" href="/unit-testing-is-simple"><time class="dt-published" datetime="2017-05-04">May 4, 2017</time></a></h2>
+      <p>This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/unit-testing-is-simple/index.html">edited on GitHub</a>.</p>
+      <p>Original article at <a href="https://dev.to/scalawilliam/unit-testing-is-simple" class="u-syndication">The Practical Dev</a>.</p>
+    </header>
+    <section class="e-content">
+        <p>Is unit testing difficult?</p>
+        <p>No, it is not. You don't even need a testing framework for it.</p>
+        <p>You don't even need to write the test in a separate file or class.</p>
+        <p>You just need to <a href="http://tldp.org/LDP/abs/html/exitcodes.html" target="_blank">exit with code 1</a>. This is enough to fail a Jenkins build and a Makefile!</p>
+        <p>Why is a unit test useful?</p>
+        <ul>
+            <li>Prevent regressions when you change the code.</li>
+            <li>Document expected input and output as code.</li>
+            <li>Replace error-prone <a href="http://codebetter.com/jeremymiller/2006/06/01/tdd-and-debugging/" target="_blank">println-driven development with test-driven development</a>.</li>
+        </ul>
+        <blockquote>
+            <p><strong>What do you test?</strong> when the logic is "complex enough" I know it could be broken 6 months down the line, due to "that one small change" - or that I'd spend time building it with print statements. <a href="https://github.com/ActionFPS/dashboard/blob/e757931de22d82edd20e4ef5ad3b2df56d433a16/test_build.py#L82" target="_blank">Example from my own code</a>.</p>
+        </blockquote>
+        <p>Here, I'll show you the most basic way to unit testing with four languages: Bash, Python, Node.js, Scala, just to prove the point.</p>
+        <p>These examples are for a very basic piece of code and are intentionally minimalistic, to demonstrate that you needn't use a test framework to get started with - though one will be very necessary when you scale your application.</p>
+        <h3>Bash</h3>
+        <p>Here's a bash script <code>inc.sh</code> with a basic assertion and some main code:</p>
+        <pre><code class="language-bash">#!/bin/bash
+
+increment() {
+    echo $(("$1"+1))
+}
+
+# If this assertion fails, the whole thing quits 
+[ 3 -eq $(increment 2) ] || exit 1
+
+# Increment a stream of numbers
+while read n; do
+    increment $n;
+done</code></pre>
+        <p>If we run:</p>
+        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-6, 8"><code class="language-bash">seq 1 5 | bash inc.sh
+2
+3
+4
+5
+6
+echo $?
+0</code></pre>
+        <p>Exit code is 0. But if we broke the function, and put 2 instead of 1, we get:</p>
+        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="3"><code class="language-bash">seq 1 5 | bash inc.sh
+echo $?
+1</code></pre>
+        <h3>Python</h3>
+        <p>This is easy to achieve in any language really. <a href="https://docs.python.org/2/reference/simple_stmts.html#the-assert-statement" target="_blank">Python assertions</a>:</p>
+        <p>Broken test in file <code>inc.py</code>:</p>
+        <pre><code class="language-python">def increment(n):
+  return n + 2
+
+assert increment(2) == 3</code></pre>
+        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-5,7"><code class="language-bash">python inc.py
+Traceback (most recent call last):
+  File "inc.py", line 4, in <module>
+    assert increment(2) == 3
+AssertionError
+echo $?
+1</code></pre>
+        <h3>Node.js</h3>
+        <p>Comes with <a href="https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message" target="_blank">assertions built in</a>.</p>
+        <p>Broken test in file <code>inc.js</code>:</p>
+        <pre><code class="language-javascript">const assert = require('assert');
+
+function increment(n) {
+  return n + 2;
+}
+
+assert.equal(2, increment(1));</code></pre>
+        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2-8,10"><code class="language-bash">node inc.js
+
+assert.js:81
+  throw new assert.AssertionError({
+  ^
+AssertionError: 2 == 3
+
+...
+echo $?
+1</code></pre>
+        <h3><a href="http://scala-lang.org/" target="_blank">Scala</a></h3>
+        <p>Comes with assert.</p>
+        <pre><code class="language-scala">def inc(n: Int) = n + 2
+assert(inc(1) == 2)</code></pre>
+        <pre class="command-line language-bash" data-user="william" data-host="localhost" data-output="2,4"><code class="language-bash">scala inc.scala
+java.lang.AssertionError: assertion failed
+echo $?
+1</code></pre>
+        <h3>Why is this important?</h3>
+        <p>You can get started light with several assertions and work your way up to proper test suites.</p>
+        <h3>So what are test frameworks for?</h3>
+        <p>To make testing more organised. You get:</p>
+        <ul>
+            <li>Organisation</li>
+            <li>Detailed error messages</li>
+            <li>Detailed test reports</li>
+            <li>Neat assertions and human readable language (see <a href="http://www.scalatest.org/" target="_blank">ScalaTest</a>)</li>
+            <li>Incremental/TDD type of development</li>
+        </ul>
+        <h2>Conclusion</h2>
+        <p>Now you have no excuse for not writing at least a few tests in your code.</p>
+    </section>
+</article>
+</body>
+</html>

--- a/unit-testing-is-simple/node-out.txt
+++ b/unit-testing-is-simple/node-out.txt
@@ -1,0 +1,10 @@
+node inc.js
+
+assert.js:81
+  throw new assert.AssertionError({
+  ^
+AssertionError: 2 == 3
+
+...
+echo $?
+1

--- a/unit-testing-is-simple/python-out.txt
+++ b/unit-testing-is-simple/python-out.txt
@@ -1,0 +1,7 @@
+python inc.py
+Traceback (most recent call last):
+  File "inc.py", line 4, in <module>
+    assert increment(2) == 3
+AssertionError
+echo $?
+1

--- a/unit-testing-is-simple/scala-out.txt
+++ b/unit-testing-is-simple/scala-out.txt
@@ -1,0 +1,4 @@
+scala inc.scala
+java.lang.AssertionError: assertion failed
+echo $?
+1


### PR DESCRIPTION
Closes #70.

Migration done just as with previous ones.

A little tweaking was done on the microformats. The `h-entry` was moved to the `body`. Not sure if it was strictly necessary but it felt neater this way.

> Also I'll pay extra $5 if you can propose well how to migrate some of the comments as well as a separate issue. They are quite good but I wouldn't know how to represent them. Post an issue for this.

No separate issue, because I had to test the microformats parsing anyway and needed an example. Apparently [not a lot of IndieWeb examples of nested comments](https://indieweb.org/comments#How_to_mark_up_nested_comments.3F) exist. This follows what does exist and the parser output makes sense as well.

> For proper syntax highlighting for all languages I'll add extra $5, as the existing examples don't come with anything other than Scala highlighting and that may be extra work.

The already included PrismJS was used to all the code snippets. This required a few extra highlighting libraries to be imported. The Command Line plugin is also loaded to render the test outputs in a nice way.