### PR TITLE
Microformats touch-ups and canonical URL fixes

### DIFF
--- a/1609/feature-switches-agile-scala-jmx/index.html
+++ b/1609/feature-switches-agile-scala-jmx/index.html
@@ -94,8 +94,8 @@ figure {
 
 <meta name="twitter:title" content="Feature Switches, Inheritance and Agile with Scala &amp; JMX on the JVM">
 <meta property="og:title" content="Feature Switches, Inheritance and Agile with Scala &amp; JMX on the JVM">
-<meta property="og:url" content="https://www.scalawilliam.com/1609/feature-switches-agile-scala-jmx/">
-<link rel="canonical" href="https://www.scalawilliam.com/1609/feature-switches-agile-scala-jmx/">
+<meta property="og:url" content="/1609/feature-switches-agile-scala-jmx/">
+<link rel="canonical" href="/1609/feature-switches-agile-scala-jmx/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2016-09-30">
@@ -118,8 +118,8 @@ figure {
 <body>
   <article class="h-entry">
     <header>
-      <h1>Feature Switches, Inheritance and Agile with Scala &amp; JMX on the JVM</h1>
-      <h2>By <a href="/" class="p-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2016-09-30T12:38:59.026Z">Sep 30, 2016</time></h2>
+      <h1 class="p-name">Feature Switches, Inheritance and Agile with Scala &amp; JMX on the JVM</h1>
+      <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/1609/feature-switches-agile-scala-jmx/" class="u-url"><time class="dt-published" datetime="2016-09-30T12:38:59.026Z">Sep 30, 2016</time></a></h2>
       This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/1609/feature-switches-agile-scala-jmx/index.html">edited on GitHub</a>.
     </header>
 
@@ -251,7 +251,7 @@ object ComplexFeature {
   all.</p>
   <p>Connect up with me <a href="https://www.linkedin.com/in/scalawilliam" target="_blank">on LinkedIn</a> and <a href="https://twitter.com/ScalaWilliam" target="_blank">Twitter</a>.</p>
   <p>&#8212;</p>
-  <p><strong>Update, <time class="dt-updated" datetime="2016-11-04 12:00:00">4 Nov 2016</time></strong>: A reader
+  <p><strong>Update, <time class="dt-updated" datetime="2016-11-04T12:00:00">4 Nov 2016</time></strong>: A reader
   gave a very good question:</p>
   <blockquote>
     So what are the downsides and upsides compared to, say, database switches?

--- a/1612/limit-degrees-of-freedom/index.html
+++ b/1612/limit-degrees-of-freedom/index.html
@@ -96,8 +96,8 @@ figure {
 <meta name="twitter:title" content="Limit degrees of freedom in development">
 <meta property="og:title" content="Limit degrees of freedom in development">
 <meta itemprop="name" content="Limit degrees of freedom in development">
-<meta property="og:url" content="/1612/limit-degrees-of-freedom">
-<link rel="canonical" href="/1612/limit-degrees-of-freedom">
+<meta property="og:url" content="/1612/limit-degrees-of-freedom/">
+<link rel="canonical" href="/1612/limit-degrees-of-freedom/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2016-12-17">
@@ -119,8 +119,8 @@ figure {
 <body>
   <article class="h-entry">
     <header>
-      <h1>Limit degrees of freedom in development</h1>
-      <h2>By <a href="/" class="u-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2016-12-17T11:21:25.101Z">December 17, 2016</time></h2>
+      <h1 class="p-name">Limit degrees of freedom in development</h1>
+      <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/1612/limit-degrees-of-freedom/" class="u-url"><time class="dt-published" datetime="2016-12-17T11:21:25.101Z">December 17, 2016</time></a></h2>
       <p>This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/1612/limit-degrees-of-freedom/index.html">edited on GitHub</a>.</p>
       <p>Original article at <a href="https://hackernoon.com/limit-degrees-of-freedom-in-development-4c543bb6f806" class="u-syndication">Hacker Noon</a>.</p>
     </header>

--- a/1704/certifications-im-considering/index.html
+++ b/1704/certifications-im-considering/index.html
@@ -96,8 +96,8 @@ figure {
 <meta name="twitter:title" content="Certifications I'm considering, as an experienced software engineer">
 <meta property="og:title" content="Certifications I'm considering, as an experienced software engineer">
 <meta itemprop="name" content="Certifications I'm considering, as an experienced software engineer">
-<meta property="og:url" content="/1704/certifications-im-considering">
-<link rel="canonical" href="/1704/certifications-im-considering">
+<meta property="og:url" content="/1704/certifications-im-considering/">
+<link rel="canonical" href="/1704/certifications-im-considering/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2017-04-29">
@@ -119,8 +119,8 @@ figure {
 <body>
   <article class="h-entry">
     <header>
-      <h1>Certifications I'm considering, as an experienced software engineer</h1>
-      <h2>By <a href="/" class="u-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2017-04-29">April 29, 2017</time></h2>
+      <h1 class="p-name">Certifications I'm considering, as an experienced software engineer</h1>
+      <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/1704/certifications-im-considering/" class="u-url"><time class="dt-published" datetime="2017-04-29">April 29, 2017</time></a></h2>
       <p>This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/1704/certifications-im-considering/index.html">edited on GitHub</a>.</p>
       <p>Original article at <a href="https://dev.to/scalawilliam/certifications-im-considering-as-an-experienced-software-engineer" class="u-syndication">The Practical Dev</a>.</p>
     </header>

--- a/1705/greenfield-technical-debt/index.html
+++ b/1705/greenfield-technical-debt/index.html
@@ -95,8 +95,8 @@ figure {
 
 <meta name="twitter:title" content="How I deal with greenfield technical debt">
 <meta property="og:title" content="How I deal with greenfield technical debt">
-<meta property="og:url" content="/1705/greenfield-technical-debt">
-<link rel="canonical" href="/1705/greenfield-technical-debt">
+<meta property="og:url" content="/1705/greenfield-technical-debt/">
+<link rel="canonical" href="/1705/greenfield-technical-debt/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2017-05-05">
@@ -119,8 +119,8 @@ figure {
 <body>
   <article class="h-entry">
     <header>
-      <h1>How I deal with greenfield technical debt</h1>
-      <h2>By <a href="/" class="u-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2017-05-05T10:47:11.753Z">May 5, 2017</time></h2>
+      <h1 class="p-name">How I deal with greenfield technical debt</h1>
+      <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/1705/greenfield-technical-debt/" class="u-url"><time class="dt-published" datetime="2017-05-05T10:47:11.753Z">May 5, 2017</time></a></h2>
       <p>This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/1705/greenfield-technical-debt/index.html">edited on GitHub</a>.</p>
       <p>Original article at <a href="https://medium.com/@ScalaWilliam/how-i-deal-with-greenfield-technical-debt-1a35be33dc71" class="u-syndication">Medium</a>.</p>
     </header>

--- a/1705/scala-android-opportunity/index.html
+++ b/1705/scala-android-opportunity/index.html
@@ -95,8 +95,8 @@ figure {
 
 <meta name="twitter:title" content="Why Scala didn't miss the Android opportunity">
 <meta property="og:title" content="Why Scala didn't miss the Android opportunity">
-<meta property="og:url" content="https://www.scalawilliam.com/scala-native-libpcap/">
-<link rel="canonical" href="https://www.scalawilliam.com/scala-native-libpcap/">
+<meta property="og:url" content="/1705/scala-android-opportunity/">
+<link rel="canonical" href="/1705/scala-android-opportunity/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2017-05-18">
@@ -119,8 +119,8 @@ figure {
 <body>
   <article class="h-entry">
     <header>
-      <h1>Why Scala didn't miss the Android opportunity</h1>
-      <h2>By <a href="/" class="p-author h-card">William Narmontas</a>, <time class="dt-published" datetime="2017-05-18T11:41:55.686Z">May 18, 2017</time></h2>
+      <h1 class="p-name">Why Scala didn't miss the Android opportunity</h1>
+      <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/1705/scala-android-opportunity/" class="u-url"><time class="dt-published" datetime="2017-05-18T11:41:55.686Z">May 18, 2017</time></a></h2>
 
       This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/1705/scala-android-opportunity/index.html">edited on GitHub</a>.
       <p>Original article at <a href="https://hackernoon.com/why-scala-didnt-miss-the-android-opportunity-92eaaf63c339" class="u-syndication">Medium</a>.</p>

--- a/scala-native-libpcap/index.html
+++ b/scala-native-libpcap/index.html
@@ -94,8 +94,8 @@ figure {
 
 <meta name="twitter:title" content="Capturing Packets with Scala Native and libpcap">
 <meta property="og:title" content="Capturing Packets with Scala Native and libpcap">
-<meta property="og:url" content="https://www.scalawilliam.com/scala-native-libpcap/">
-<link rel="canonical" href="https://www.scalawilliam.com/scala-native-libpcap/">
+<meta property="og:url" content="/scala-native-libpcap/">
+<link rel="canonical" href="/scala-native-libpcap/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2017-03-26">
@@ -115,10 +115,10 @@ figure {
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@ScalaWilliam">
 </head>
-<body>
+<body class="h-entry">
     <header>
-        <h1>Capturing Packets with Scala Native and libpcap</h1>
-        <h2>By <a href="/">William Narmontas</a>, March 2017</h2>
+        <h1 class="p-name">Capturing Packets with Scala Native and libpcap</h1>
+        <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/scala-native-libpcap/" class="u-url"><time class="dt-published" datetime="2017-03-26">March 2017</time></a></h2>
         <p>Scala application (updated July 2017): <a href="https://github.com/ScalaWilliam/scala-native-libpcap">ScalaWilliam/scala-native-libpcap @ GitHub</a> (<a href="https://github.com/ScalaWilliam/scala-native-libpcap/blob/master/src/main/scala/PcapExample.scala">PcapExample.scala</a>).
             This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/scala-native-libpcap/index.html">edited on GitHub</a>.</p>
     </header>
@@ -129,7 +129,7 @@ figure {
             <li> Test 1</li>
         </ul>
     </nav>
-    <article>
+    <article class="e-content">
 <section>
     <h2>Background</h2>
     

--- a/unit-testing-is-simple/index.html
+++ b/unit-testing-is-simple/index.html
@@ -126,8 +126,8 @@ figure {
 <meta name="twitter:title" content="Unit testing is simple">
 <meta property="og:title" content="Unit testing is simple">
 <meta itemprop="name" content="Unit testing is simple">
-<meta property="og:url" content="/unit-testing-is-simple">
-<link rel="canonical" href="/unit-testing-is-simple">
+<meta property="og:url" content="/unit-testing-is-simple/">
+<link rel="canonical" href="/unit-testing-is-simple/">
 <!-- http://ogp.me/ -->
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2017-05-04">
@@ -150,7 +150,7 @@ figure {
   <article>
     <header>
       <h1 class="p-name">Unit testing is simple</h1>
-      <h2>By <a href="/" class="u-author h-card">William Narmontas</a>, <a class="u-url" href="/unit-testing-is-simple"><time class="dt-published" datetime="2017-05-04">May 4, 2017</time></a></h2>
+      <h2>By <a href="/" class="u-author">William Narmontas</a>, <a href="/unit-testing-is-simple/" class="u-url"><time class="dt-published" datetime="2017-05-04">May 4, 2017</time></a></h2>
       <p>This page can be <a href="https://github.com/ScalaWilliam/ScalaWilliam.com/blob/master/unit-testing-is-simple/index.html">edited on GitHub</a>.</p>
       <p>Original article at <a href="https://dev.to/scalawilliam/unit-testing-is-simple" class="u-syndication">The Practical Dev</a>.</p>
     </header>


### PR DESCRIPTION
Here are some fixes I mentioned on IRC. Finally got around to them.

1. Make sure all articles specify a `p-name`, this was forgotten in the first microformats iteration although essential for parsing.
2. Give a `u-url` value to the `h-entry` objects. Now a parsed microformats entry will know its URL. Use the canonical URL for this. As a bonus, canonical URLs have been tweaked in the `LINK` element to be domain-relative and include a trailing slash (`/`) everywhere.
3. Remove `h-card` from byline. I admit, this was my own mistake. We don’t want parsers to use the local h-card, instead we want them to [apply the authorship algorithm](https://indieweb.org/authorship#How_to_determine) and parse the h-card on the homepage. This means a display picture for the author can be found, etc.

I went through all the articles linked on the current master branch. Those that still needed migrating have PRs filed (#81, #82, #83) and should already be using correct microformats. I skipped the older articles that were published before the POSSE issue #55 was created, because most of them were on a slightly different layout with a different footer. The exception being `/scala-native-libpcap/` as all recent migrations were based off of that.

When all articles are live on ScalaWilliam.com some work might need to be done to make sure the surrounding page is the same for all articles. Same footer with social media links. Or no footer at all, as with the later migrated. That’s for a different issue.